### PR TITLE
fix(valgrind): tie --separate-threads to subprocess tracking

### DIFF
--- a/src/executor/valgrind/measure.rs
+++ b/src/executor/valgrind/measure.rs
@@ -33,19 +33,18 @@ fn get_valgrind_args(tool: &SimulationTool, config: &ExecutorConfig) -> Vec<Stri
     .map(|x| x.to_string())
     .collect();
 
-    args.push(if config.simulation_track_subprocess {
-        "--instr-atstart=inherit".to_string()
+    if config.simulation_track_subprocess {
+        args.push("--instr-atstart=inherit".to_string());
+        args.push("--separate-threads=yes".to_string());
     } else {
-        "--instr-atstart=no".to_string()
-    });
+        args.push("--instr-atstart=no".to_string());
+        args.push("--separate-threads=no".to_string());
+    }
 
     match tool {
         SimulationTool::Callgrind => {
             if config.cycle_estimation {
                 args.push("--cycle-estimation=yes".to_string());
-                args.push("--separate-threads=yes".to_string());
-            } else {
-                args.push("--separate-threads=no".to_string());
             }
 
             args.push("--tool=callgrind".to_string());


### PR DESCRIPTION
`--separate-threads` was keyed on `--cycle-estimation`, which is unrelated: cycle estimation changes how event costs are computed, not how they are partitioned across threads. As a side effect, turning cycle estimation off silently also merged thread data, and turning it on split it.

Per-thread dumps only matter when instrumentation is inherited across a traced exec (`--instr-atstart=inherit`), so the option now follows `simulation_track_subprocess` and is set explicitly in both branches:

- tracking subprocesses: `--instr-atstart=inherit --separate-threads=yes`
- otherwise: `--instr-atstart=no --separate-threads=no` (valgrind's default, so no behavior change for existing runs)

The flag now sits in the tool-agnostic branch rather than the callgrind arm. That is safe: tracegrind is a fork of callgrind and accepts `--separate-threads` in its own option parser, same as callgrind.