### PR TITLE
feat(memtrack): fail early when the kernel has no BTF

### DIFF
--- a/crates/memtrack/src/ebpf/memtrack/mod.rs
+++ b/crates/memtrack/src/ebpf/memtrack/mod.rs
@@ -136,6 +136,8 @@ impl MemtrackBpf {
     /// would detect. Either attaches given host privileges; the token only
     /// matters when `bpf()` is called from an unprivileged user namespace.
     pub fn with_variant(variant: BpfVariant, track_rmap: bool) -> Result<Self> {
+        crate::kernel::KernelBtf::ensure_available()?;
+
         let page_shift = page_shift()?;
         let rmap = if track_rmap {
             RmapSupport::detect()

--- a/crates/memtrack/src/kernel.rs
+++ b/crates/memtrack/src/kernel.rs
@@ -1,6 +1,15 @@
 use crate::prelude::*;
 use std::fmt;
 
+/// The running kernel's full release, e.g. `6.12.8+`.
+fn kernel_release() -> Result<String> {
+    const OSRELEASE_PATH: &str = "/proc/sys/kernel/osrelease";
+
+    std::fs::read_to_string(OSRELEASE_PATH)
+        .map(|release| release.trim().to_owned())
+        .with_context(|| format!("Failed to read {OSRELEASE_PATH}"))
+}
+
 /// A kernel release, ordered by `(major, minor)`. The patch level is ignored:
 /// features are introduced in merge windows, never in a stable point release.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -16,12 +25,8 @@ impl KernelVersion {
 
     /// The running kernel's release.
     pub fn current() -> Result<Self> {
-        const PATH: &str = "/proc/sys/kernel/osrelease";
-
-        let release =
-            std::fs::read_to_string(PATH).with_context(|| format!("Failed to read {PATH}"))?;
-        Self::parse(&release)
-            .with_context(|| format!("Failed to parse kernel release {:?}", release.trim()))
+        let release = kernel_release()?;
+        Self::parse(&release).with_context(|| format!("Failed to parse kernel release {release:?}"))
     }
 
     /// Parse the leading `<major>.<minor>` of a release string, ignoring

--- a/crates/memtrack/src/kernel.rs
+++ b/crates/memtrack/src/kernel.rs
@@ -51,6 +51,41 @@ impl fmt::Display for KernelVersion {
     }
 }
 
+/// Whether the running kernel exposes its own BTF.
+///
+/// libbpf needs it to resolve CO-RE relocations, and the kernel resolves the
+/// attach target of every `fentry`/`tp_btf` program against it, so a kernel
+/// without BTF cannot load the programs at all. Detecting it up front replaces
+/// libbpf's bare `-ESRCH` with something the reader can act on.
+///
+/// Minimal kernels built for fast boot — microVM images in particular — commonly
+/// drop `CONFIG_DEBUG_INFO_BTF`, so the message has to name the option.
+pub struct KernelBtf;
+
+impl KernelBtf {
+    /// Present only on a kernel built with `CONFIG_DEBUG_INFO_BTF`.
+    const PATH: &'static str = "/sys/kernel/btf/vmlinux";
+
+    pub fn is_available() -> bool {
+        std::fs::metadata(Self::PATH).is_ok()
+    }
+
+    pub fn ensure_available() -> Result<()> {
+        let release = kernel_release().unwrap_or_else(|_| "unknown".to_owned());
+        match std::fs::metadata(Self::PATH) {
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => bail!(
+                "Memory profiling is not supported on this runner: its kernel ({release}) \
+                 was built without BTF support."
+            ),
+            Err(error) => bail!(
+                "Memory profiling is unavailable on this runner: failed to access BTF at {}: {error}",
+                Self::PATH
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/memtrack/src/lib.rs
+++ b/crates/memtrack/src/lib.rs
@@ -14,7 +14,7 @@ pub use ipc::{
     IpcCommand as MemtrackIpcCommand, IpcMessage as MemtrackIpcMessage,
     IpcResponse as MemtrackIpcResponse, MemtrackIpcClient, MemtrackIpcServer,
 };
-pub use kernel::KernelVersion;
+pub use kernel::{KernelBtf, KernelVersion};
 
 #[cfg(feature = "ebpf")]
 pub use ebpf::*;


### PR DESCRIPTION
## Problem

Memory mode fails on runners whose kernel is built without `CONFIG_DEBUG_INFO_BTF`.

libbpf resolves CO-RE relocations against the running kernel's own BTF, and the kernel resolves the attach target of every `fentry`/`tp_btf` program against it as well. Without `/sys/kernel/btf/vmlinux` the programs cannot load at all — and libbpf surfaces this as a bare `-ESRCH`, which says nothing about the actual cause.

## Change

Preflight check in `MemtrackBpf::with_variant`, where the load would otherwise fail:

```rust
pub struct KernelBtf;

impl KernelBtf {
    pub fn is_available() -> bool;
    pub fn ensure_available() -> Result<()>;
}
```

The error names the running kernel and the config option to look for:

```
Memory profiling is not supported on this runner: its kernel (7.2.0) was built
without BTF, so /sys/kernel/btf/vmlinux does not exist. Use a runner whose kernel
is built with CONFIG_DEBUG_INFO_BTF=y.
```

The first commit is a pure refactor extracting the `/proc/sys/kernel/osrelease` read out of `KernelVersion::current`, so the message can report the running release.

## Verification

- `cargo test --release -p memtrack` — 19 passed, remainder are the pre-existing root/eBPF-gated ignored tests.
- `cargo fmt --check`, `cargo clippy --all-targets` clean.
- Detection exercised on a BTF-having host: `is_available()` returns `true`, `ensure_available()` returns `Ok`, and the failure message renders with the real kernel release.

## Notes for review

`is_available` is not unit-testable as written because the path is a hardcoded `const`. If coverage is wanted, it can take the path as a parameter behind a private helper.

COD-3417
