### PR TITLE
feat: add --memory-track-physical experimental flag

### DIFF
--- a/src/cli/exec/mod.rs
+++ b/src/cli/exec/mod.rs
@@ -93,6 +93,7 @@ fn build_orchestrator_config(
         cycle_estimation: args.shared.cycle_estimation,
         exclude_allocations: args.shared.exclude_allocations,
         simulation_track_subprocess: args.shared.simulation_track_subprocess,
+        memory_track_physical: args.shared.experimental.experimental_memory_track_physical,
     })
 }
 

--- a/src/cli/experimental.rs
+++ b/src/cli/experimental.rs
@@ -17,6 +17,16 @@ pub struct ExperimentalArgs {
     )]
     pub experimental_fair_sched: bool,
 
+    /// Enable physical (resident) memory tracking in memory mode.
+    #[arg(
+        long,
+        default_value_t = false,
+        help_heading = "Experimental",
+        env = "CODSPEED_MEMTRACK_TRACK_PHYSICAL",
+        value_parser = clap::builder::FalseyValueParser::new()
+    )]
+    pub experimental_memory_track_physical: bool,
+
     /// Deprecated: cycle estimation is enabled by default and this flag has no effect.
     #[arg(long, hide = true, env = "CODSPEED_EXPERIMENTAL_CYCLE_ESTIMATION")]
     pub experimental_cycle_estimation: bool,
@@ -32,6 +42,9 @@ impl ExperimentalArgs {
         let mut flags = Vec::new();
         if self.experimental_fair_sched {
             flags.push("--experimental-fair-sched");
+        }
+        if self.experimental_memory_track_physical {
+            flags.push("--experimental-memory-track-physical");
         }
         flags
     }

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -83,6 +83,7 @@ impl RunArgs {
                     experimental_fair_sched: false,
                     experimental_cycle_estimation: false,
                     experimental_exclude_allocations: false,
+                    experimental_memory_track_physical: false,
                 },
             },
             instruments: vec![],
@@ -135,6 +136,7 @@ fn build_orchestrator_config(
         cycle_estimation: args.shared.cycle_estimation,
         exclude_allocations: args.shared.exclude_allocations,
         simulation_track_subprocess: args.shared.simulation_track_subprocess,
+        memory_track_physical: args.shared.experimental.experimental_memory_track_physical,
     })
 }
 

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -140,8 +140,10 @@ pub struct ExecutorConfig {
     /// Inherit valgrind's instrumentation state across a traced exec, so the cost of
     /// subprocesses spawned by a benchmark is measured too.
     pub simulation_track_subprocess: bool,
-    /// Enable physical (resident) memory tracking in memory mode. Forwarded to
-    /// the memtrack subprocess as `CODSPEED_MEMTRACK_TRACK_PHYSICAL`.
+    /// Enable physical (resident) memory tracking in memory mode.
+    ///
+    /// Only read by the memory executor, which is Linux-only.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub memory_track_physical: bool,
 }
 

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -98,6 +98,8 @@ pub struct OrchestratorConfig {
     /// Inherit valgrind's instrumentation state across a traced exec, so the cost of
     /// subprocesses spawned by a benchmark is measured too.
     pub simulation_track_subprocess: bool,
+    /// Enable physical (resident) memory tracking in memory mode.
+    pub memory_track_physical: bool,
 }
 
 /// Per-execution configuration passed to executors.
@@ -138,6 +140,9 @@ pub struct ExecutorConfig {
     /// Inherit valgrind's instrumentation state across a traced exec, so the cost of
     /// subprocesses spawned by a benchmark is measured too.
     pub simulation_track_subprocess: bool,
+    /// Enable physical (resident) memory tracking in memory mode. Forwarded to
+    /// the memtrack subprocess as `CODSPEED_MEMTRACK_TRACK_PHYSICAL`.
+    pub memory_track_physical: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -210,6 +215,7 @@ impl OrchestratorConfig {
             cycle_estimation: self.cycle_estimation,
             exclude_allocations: self.exclude_allocations,
             simulation_track_subprocess: self.simulation_track_subprocess,
+            memory_track_physical: self.memory_track_physical,
         }
     }
 }
@@ -245,6 +251,7 @@ impl OrchestratorConfig {
             cycle_estimation: true,
             exclude_allocations: false,
             simulation_track_subprocess: false,
+            memory_track_physical: false,
         }
     }
 }

--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -63,6 +63,9 @@ impl MemoryExecutor {
 
         // Build the memtrack command
         let mut cmd_builder = CommandBuilder::new(MEMTRACK_COMMAND);
+        if execution_context.config.memory_track_physical {
+            cmd_builder.env("CODSPEED_MEMTRACK_TRACK_PHYSICAL", "1");
+        }
         cmd_builder.arg("track");
         cmd_builder.arg("--output");
         cmd_builder.arg(execution_context.profile_folder.join("results"));


### PR DESCRIPTION
## What

Adds an experimental `--memory-track-physical` flag to `codspeed run` and `codspeed exec`. When set, it forwards `CODSPEED_MEMTRACK_TRACK_PHYSICAL=1` to the memtrack subprocess, enabling the `rss_stat` tracepoint plus the folio rmap hooks for physical (resident) memory reconstruction.

## Why

memtrack already gates this behind the `CODSPEED_MEMTRACK_TRACK_PHYSICAL` env var (`crates/memtrack/src/ebpf/tracker.rs`), inherited implicitly by the subprocess. This adds a discoverable, documented CLI flag under the `Experimental` heading (with the standard experimental-flag warning banner), while keeping the underlying env var identical so standalone memtrack usage is unaffected.

## Implementation

- `ExperimentalArgs::experimental_memory_track_physical` (`--memory-track-physical`, env `CODSPEED_MEMTRACK_TRACK_PHYSICAL`), using `FalseyValueParser` so the env var's `1` value parses correctly (clap's default bool parser only accepts `true`/`false`).
- Threaded through `OrchestratorConfig` / `ExecutorConfig` alongside the existing valgrind experimental flags (`fair_sched`, etc.).
- `MemoryExecutor::build_memtrack_command` sets `CODSPEED_MEMTRACK_TRACK_PHYSICAL=1` on the memtrack subprocess's environment when the flag is enabled. Default (off) behavior is unchanged, and a user-exported env var still works exactly as before (no CLI flag required).

## Verification

- `cargo check --workspace --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets` all clean.
- `cargo test --release -p codspeed-runner --lib` — all cli/config tests pass (the only failures are pre-existing sudo-gated walltime/valgrind tests unrelated to this change, failing on this box due to no passwordless sudo).
- Manually verified via `codspeed exec --mode memory`:
  - `--memory-track-physical` prints the experimental warning banner.
  - `CODSPEED_MEMTRACK_TRACK_PHYSICAL=1` (matching memtrack's own convention) also enables it.
  - Omitting both leaves the flag off (default).
