### PR TITLE
chore: pin memtrack 1.5.0

### DIFF
--- a/src/binary_pins.rs
+++ b/src/binary_pins.rs
@@ -109,9 +109,9 @@ impl ValgrindTarget {
 }
 
 const MEMTRACK_INSTALLER: BinaryPin = BinaryPin {
-    version: "1.4.0",
+    version: "1.5.0",
     url_template: "https://github.com/CodSpeedHQ/codspeed/releases/download/memtrack-v{version}/memtrack-installer.sh",
-    sha256: "bbc6aac54bac8ec93c1f37ce341811b02ab31e39a211cf6c80a2ee80c2f088f6",
+    sha256: "ac18ecae4693cce84ada6078d284ac4307d8cdb055c65ac9569622f4c33bfadb",
 };
 #[cfg(target_os = "linux")]
 pub const MEMTRACK_VERSION: &str = MEMTRACK_INSTALLER.version;


### PR DESCRIPTION
Point the runner at memtrack 1.5.0, which ships physical (resident) memory
tracking. The feature stays off unless
`--experimental-memory-track-physical` (or
`CODSPEED_MEMTRACK_TRACK_PHYSICAL=1`) is passed.

Refs COD-3499 — the issue stays open until the runner release that carries
this pin.
