### PR TITLE
feat(runner): wire CoreCLR symbolization for walltime .NET runs

### DIFF
--- a/src/executor/wall_time/profiler/samply/mod.rs
+++ b/src/executor/wall_time/profiler/samply/mod.rs
@@ -92,6 +92,8 @@ impl Profiler for SamplyProfiler {
         let samply_builder = InternalCommands::Samply(SamplyArgs {
             args: vec![
                 "record".into(),
+                // Enable Samply's CoreCLR support so managed JIT frames are symbolized.
+                "--coreclr=enabled".into(),
                 "--presymbolicate".into(),
                 "--no-open".into(),
                 "--save-only".into(),


### PR DESCRIPTION
## Summary

- enable Samply's CoreCLR support for walltime profiles
- preserve existing runtime environment values through Samply's unset-only behavior
- make managed .NET JIT frames available for symbolization

## Verification

- `cargo check -p codspeed-runner`
- repository pre-commit checks, including fmt and clippy
