### PR TITLE
fix: escape single quotes in forwarded env values

### DIFF
--- a/src/executor/helpers/run_with_env.rs
+++ b/src/executor/helpers/run_with_env.rs
@@ -83,10 +83,9 @@ mod tests {
 
         let output = Command::new("bash")
             .arg("-c")
-            .arg(format!(
-                "source {} && printf %s \"$CODSPEED_TEST_VALUE\"",
-                env_file.path().display()
-            ))
+            .arg("source \"$1\" && printf %s \"$CODSPEED_TEST_VALUE\"")
+            .arg("bash")
+            .arg(env_file.path())
             .output()
             .unwrap();
 

--- a/src/executor/helpers/run_with_env.rs
+++ b/src/executor/helpers/run_with_env.rs
@@ -61,7 +61,7 @@ fn create_env_file(extra_env: &HashMap<String, String>) -> Result<NamedTempFile>
     let system_env = get_exported_system_env()?;
     let base_injected_env = extra_env
         .iter()
-        .map(|(k, v)| format!("export {k}='{v}'"))
+        .map(|(k, v)| format!("export {k}='{}'", v.replace('\'', r"'\''")))
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -69,4 +69,32 @@ fn create_env_file(extra_env: &HashMap<String, String>) -> Result<NamedTempFile>
     let mut env_file = NamedTempFile::new()?;
     env_file.write_all(format!("{system_env}\n{base_injected_env}").as_bytes())?;
     Ok(env_file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_env_file_preserves_single_quotes() {
+        let value = "/tmp/it's a profile folder";
+        let extra_env = HashMap::from([("CODSPEED_TEST_VALUE".to_string(), value.to_string())]);
+        let env_file = create_env_file(&extra_env).unwrap();
+
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "source {} && printf %s \"$CODSPEED_TEST_VALUE\"",
+                env_file.path().display()
+            ))
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), value);
+    }
 }


### PR DESCRIPTION
I was reading the history of `run_with_env.rs` and noticed that 340d9ab fixed values with spaces by wrapping them in single quotes (`export {k}='{v}'`), but nothing escapes a single quote inside the value. Such a value closes the quoting early, the env file no longer sources, and the benchmark never starts.

The values written there include the `--profile-folder` path and the user's `PATH`, so this is reachable from the CLI. On current main (37eba9e), on Linux:

```
$ CODSPEED_PROFILER_ENABLED=false codspeed exec --skip-upload --mode walltime --profile-folder "/tmp/it's here" -- echo hello

› Running the benchmarks

/tmp/.tmpW2PMqD: line 27: unexpected EOF while looking for matching `''
  ✗ failed to execute the benchmark process: exit status: 2
```

With this branch the same command runs the benchmark and exits 0.

The fix escapes embedded quotes as `'\''`, so values without a quote produce exactly the same line as before. The memory executor goes through the same `create_env_file` via `prefix_command_with_env`, so it gets the fix too. I only ran the walltime path end to end.

I added a unit test that writes an env file with a quoted value, sources it with bash and checks the value comes back unchanged. It fails on main with the error above and passes with the change. `cargo fmt --check` is clean and clippy reports nothing in this file.

AI tools used
